### PR TITLE
Fix tabsNav undefined error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,9 @@
   "content_scripts": [
     {
       "matches": [
-        "*://dashboard.microverse.org/*"
+        "https://dashboard.microverse.org/projects", 
+        "https://dashboard.microverse.org/challenges_progress", 
+        "https://dashboard.microverse.org/professional_skills_progress"
       ],
       "js": [
         "filter.js"


### PR DESCRIPTION
# Fix tabsNav undefined error

The error occurs when the user accesses other pages, i.e., pages where `tabs-animated-shadow tabs-animated nav` is not present. Since `tabsNav` stores that DOM object, it shows undefined when not found. 

I changed the `manifest` file to only match for `Projects`, `Coding Challenges` and `Professional Skills` page.